### PR TITLE
delta_matrix をフォールバックとして再実装（後方互換性強化）

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,12 @@
       "Bash(gh issue comment:*)",
       "Bash(git pull:*)",
       "Bash(dir \"%APPDATA%\\Blender Foundation\\Blender\")",
-      "Bash(powershell -Command \"Get-ChildItem ''$env:APPDATA\\Blender Foundation\\Blender'' -Directory | Select-Object Name\")"
+      "Bash(powershell -Command \"Get-ChildItem ''$env:APPDATA\\Blender Foundation\\Blender'' -Directory | Select-Object Name\")",
+      "Bash(gh release create v0.1.0 --title \"v0.1.0 - Initial Community Fork\" --notes \"$(cat <<''EOF''\n## MochiFitter-Kai v0.1.0\n\n[MochiFitter](https://booth.pm/ja/items/7657840) のコミュニティフォーク初回リリース\n\n### 主な変更点\n\n#### delta_matrix 廃止\n- posediff JSON から `delta_matrix` フィールドを削除\n- ユーザーが `location`, `rotation`, `scale` を直接編集可能に\n- Unity 側は `hasDeltaMatrix` フォールバックで互換性維持\n\n#### アドオン情報の更新\n- アドオン名を「MochiFitter-Kai」に変更\n- 非公式版であることを明記\n- GitHub リポジトリへのリンクを追加\n\n### インストール方法\n\n1. [MochiFitter-BlenderAddon](https://github.com/Mega-Gorilla/MochiFitter-BlenderAddon-kai/tree/master/MochiFitter-BlenderAddon) フォルダをダウンロード\n2. Blender の `Edit` → `Preferences` → `Add-ons` → `Install...`\n3. ダウンロードしたフォルダを選択してインストール\n\n### 動作要件\n\n- Blender 4.0 以上\n- SciPy（アドオン内の再インストールボタンで導入可能）\n\n---\n\n⚠️ **注意**: これは非公式のコミュニティフォークです。本家 MochiFitter のサポートは [BOOTH](https://booth.pm/ja/items/7657840) をご確認ください。\nEOF\n)\")",
+      "Bash(dir:*)",
+      "Bash(findstr:*)",
+      "Bash(powershell:*)",
+      "Bash(gh issue reopen:*)"
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `delta_matrix` をフォールバックとして再実装 - 後方互換性を強化
+  - `location`, `rotation`, `scale` フィールドを優先的に使用
+  - これらが存在しない古いJSONでは `delta_matrix` にフォールバック
+  - KeyError による読み込み失敗を防止
+
+### Removed
+- 未使用の `matrix_to_list()` 関数を削除
+
 ## [0.1.0] - 2024-12-14
 
 ### Added
@@ -28,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - ユーザーが posediff JSON の scale 値を編集しても反映されなかった問題を修正
+
+### Notes
+- **精度に関する注意**: 以前は保存された `delta_matrix` をそのまま適用していましたが、
+  現在は `location`, `rotation`, `scale` から行列を再構築しています。
+  非等方スケールや特殊な回転を含む場合、わずかな数値誤差が生じる可能性があります。
 
 ---
 


### PR DESCRIPTION
## Summary

PR #2 のレビュー指摘に基づく修正です。

- `location`, `rotation`, `scale` フィールドを優先的に使用
- これらが存在しない古いJSONでは `delta_matrix` にフォールバック
- 未使用の `matrix_to_list()` 関数を削除
- CHANGELOG に精度面の注意点を追記

## 変更内容

### 後方互換性の強化
古いposediff JSONファイル（`delta_matrix`のみを含む）を読み込む際に KeyError が発生する問題を修正しました。

```python
# 優先: location/rotation/scale から行列を構築
if 'location' in bone_pose and 'rotation' in bone_pose and 'scale' in bone_pose:
    # 新しいフォーマット
    ...
elif 'delta_matrix' in bone_pose:
    # フォールバック: 古いフォーマット
    delta_matrix = list_to_matrix(bone_pose['delta_matrix'])
```

### コードクリーンアップ
- `matrix_to_list()`: 削除（保存時に使用されなくなったため）
- `list_to_matrix()`: 残存（フォールバック用、docstring更新）

## Test plan

- [ ] 新しいposediff JSON（location/rotation/scale のみ）が正しく読み込まれること
- [ ] 古いposediff JSON（delta_matrix を含む）が正しく読み込まれること
- [ ] スケール編集が正しく反映されること

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)