### PR TITLE
chore: Add auto version bump workflow

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,71 @@
+name: Auto Version Bump
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+jobs:
+  bump-version:
+    # PRがマージされた場合のみ実行
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          INIT_FILE="MochiFitter-BlenderAddon/__init__.py"
+
+          # 現在のバージョンを取得
+          CURRENT_VERSION=$(grep -oP '"version":\s*\(\K[0-9]+,\s*[0-9]+,\s*[0-9]+' "$INIT_FILE")
+          MAJOR=$(echo "$CURRENT_VERSION" | cut -d',' -f1 | tr -d ' ')
+          MINOR=$(echo "$CURRENT_VERSION" | cut -d',' -f2 | tr -d ' ')
+          PATCH=$(echo "$CURRENT_VERSION" | cut -d',' -f3 | tr -d ' ')
+
+          # パッチバージョンをインクリメント
+          NEW_PATCH=$((PATCH + 1))
+
+          echo "Current: $MAJOR.$MINOR.$PATCH"
+          echo "New: $MAJOR.$MINOR.$NEW_PATCH"
+
+          # ファイルを更新
+          sed -i "s/\"version\": ($MAJOR, $MINOR, $PATCH)/\"version\": ($MAJOR, $MINOR, $NEW_PATCH)/" "$INIT_FILE"
+
+          # 出力を設定
+          echo "old_version=$MAJOR.$MINOR.$PATCH" >> $GITHUB_OUTPUT
+          echo "new_version=$MAJOR.$MINOR.$NEW_PATCH" >> $GITHUB_OUTPUT
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add MochiFitter-BlenderAddon/__init__.py
+          git commit -m "chore: bump version to v${{ steps.bump.outputs.new_version }} [skip ci]"
+          git push
+
+      - name: Summary
+        run: |
+          echo "## Version Bump Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **PR**: #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Previous**: v${{ steps.bump.outputs.old_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **New**: v${{ steps.bump.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

PRマージ時にパッチバージョンを自動インクリメントする GitHub Actions ワークフローを追加します。

## バージョン管理ポリシー

| タイミング | 対応 |
|------------|------|
| PR内のコミット | バージョン更新しない |
| main へマージ時 | **自動で** patch バージョンを +1 |
| 重要な変更時 | 手動で minor/major を設定 |

## ワークフロー詳細

`.github/workflows/auto-version-bump.yml`:

- **トリガー**: PR が master にマージされた時のみ
- **処理**: `__init__.py` の patch バージョンを +1
- **コミット**: `[skip ci]` 付きで無限ループ防止

## 例

```
PR #8 マージ前: v0.2.0
PR #8 マージ後: v0.2.1 (自動)
```

## Test plan

- [ ] PRをマージしてワークフローが実行されることを確認
- [ ] バージョンが正しくインクリメントされることを確認
- [ ] `[skip ci]` でワークフローが再トリガーされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)