### PR TITLE
fix: 線形システム求解のパフォーマンス改善

### DIFF
--- a/MochiFitter-BlenderAddon/rbf_multithread_processor.py
+++ b/MochiFitter-BlenderAddon/rbf_multithread_processor.py
@@ -438,13 +438,17 @@ def rbf_interpolation_multithread(source_control_points: np.ndarray,
 
     # ProcessPoolExecutor 開始直前に BLAS スレッド数を制限
     # np.linalg.solve() は既に完了しているので、ここからは並列処理のオーバーサブスクライブ防止のため制限
-    blas_threads = '2'
-    os.environ['OMP_NUM_THREADS'] = blas_threads
-    os.environ['OPENBLAS_NUM_THREADS'] = blas_threads
-    os.environ['MKL_NUM_THREADS'] = blas_threads
-    os.environ['VECLIB_MAXIMUM_THREADS'] = blas_threads
-    os.environ['NUMEXPR_NUM_THREADS'] = blas_threads
-    print(f"BLAS スレッド数を {blas_threads} に制限しました（ProcessPoolExecutor 開始前）")
+    # max_workers == 1 の場合は制限不要（低メモリモード等で単一ワーカーの場合はフルスレッド活用）
+    if max_workers == 1:
+        print("単一ワーカーモード: BLAS スレッド制限なし（フルスレッド活用）")
+    else:
+        blas_threads = '2'
+        os.environ['OMP_NUM_THREADS'] = blas_threads
+        os.environ['OPENBLAS_NUM_THREADS'] = blas_threads
+        os.environ['MKL_NUM_THREADS'] = blas_threads
+        os.environ['VECLIB_MAXIMUM_THREADS'] = blas_threads
+        os.environ['NUMEXPR_NUM_THREADS'] = blas_threads
+        print(f"BLAS スレッド数を {blas_threads} に制限しました（ProcessPoolExecutor 開始前、ワーカー数: {max_workers}）")
     
     # マルチプロセス処理
     processed_count = 0


### PR DESCRIPTION
## Summary

テスト中に発見された「線形システムを解いています...」で処理が止まる問題を修正します。

### 根本原因

`main()` で BLAS スレッド数を '2' に制限していましたが、`np.linalg.solve()` は **ProcessPoolExecutor の前に**メインプロセスで実行されます。

```
処理フロー（修正前）:
1. main() → BLAS スレッド '2' に制限 ← 問題
2. np.linalg.solve() → スレッド制限で遅い
3. ProcessPoolExecutor → 制限は適切
```

### 解決策

BLAS スレッド制限を ProcessPoolExecutor 開始直前に移動：

```
処理フロー（修正後）:
1. main() → BLAS 制限なし
2. np.linalg.solve() → フルスレッドで高速
3. BLAS スレッド '2' に制限
4. ProcessPoolExecutor → 制限で安定
```

### 変更内容

| 項目 | 変更 |
|------|------|
| `main()` | BLAS 制限を削除 |
| `multiprocess_rbf_interpolation()` | ProcessPoolExecutor 直前で BLAS 制限 |
| 線形システム求解 | 行列サイズと処理時間を表示 |

## Test plan

- [ ] 「線形システムを解いています...」で止まらず処理が進む
- [ ] 行列サイズと処理時間が表示される（例: `線形システム求解完了（2.35秒）`）
- [ ] ProcessPoolExecutor のバッチ処理が正常に動作する
- [ ] システム全体が重くならない

🤖 Generated with [Claude Code](https://claude.com/claude-code)