### PR TITLE
fix(unity-addon): ハードコードパスを削除しCLIラッパーの移植性を向上

### DIFF
--- a/MochFitter-unity-addon/OutfitRetargetingSystem/README.md
+++ b/MochFitter-unity-addon/OutfitRetargetingSystem/README.md
@@ -63,6 +63,40 @@ OutfitRetargetingSystem/
 
 Unity を介さずに `retarget_script2_14.py` を直接実行してテストできます。
 
+### 環境変数の設定
+
+以下の環境変数を設定してください：
+
+| 環境変数 | 説明 | 例 |
+|---------|------|-----|
+| `BLENDER_PATH` | Blender 実行ファイルのパス | `C:\Program Files\Blender Foundation\Blender 4.0\blender.exe` |
+| `RETARGET_SCRIPT_PATH` | retarget_script2_14.py のパス | `D:\BlenderTools\dev\retarget_script2_14.py` |
+
+**PowerShell での設定例:**
+```powershell
+$env:BLENDER_PATH = "C:\Program Files\Blender Foundation\Blender 4.0\blender.exe"
+$env:RETARGET_SCRIPT_PATH = "D:\path\to\retarget_script2_14.py"
+```
+
+**コマンドプロンプト での設定例:**
+```batch
+set BLENDER_PATH=C:\Program Files\Blender Foundation\Blender 4.0\blender.exe
+set RETARGET_SCRIPT_PATH=D:\path\to\retarget_script2_14.py
+```
+
+### CLI ラッパースクリプト（推奨）
+
+`run_retarget.py` を使用すると簡単にテストできます：
+
+```batch
+python run_retarget.py --preset beryl_to_mao --benchmark
+```
+
+オプション:
+- `--preset`: プリセット設定を使用（`beryl_to_mao`）
+- `--benchmark`: ベンチマーク結果を記録
+- `--list-presets`: 利用可能なプリセットを表示
+
 ### 必要なファイル配置
 
 ```

--- a/MochFitter-unity-addon/OutfitRetargetingSystem/run_retarget.py
+++ b/MochFitter-unity-addon/OutfitRetargetingSystem/run_retarget.py
@@ -67,10 +67,10 @@ def find_blender() -> Path:
 
     # Common installation paths (Windows)
     common_paths = [
-        Path(r"D:\vrchat\mao_avator - mochifitter\BlenderTools\blender-4.0.2-windows-x64\blender.exe"),
         Path(r"C:\Program Files\Blender Foundation\Blender 4.0\blender.exe"),
         Path(r"C:\Program Files\Blender Foundation\Blender 4.1\blender.exe"),
         Path(r"C:\Program Files\Blender Foundation\Blender 4.2\blender.exe"),
+        Path(r"C:\Program Files\Blender Foundation\Blender 4.3\blender.exe"),
     ]
     for p in common_paths:
         if p.exists():
@@ -87,18 +87,26 @@ def find_blender() -> Path:
 
 
 def find_retarget_script() -> Path:
-    """Find retarget_script2_14.py."""
+    """Find retarget_script2_14.py.
+
+    Search order:
+    1. RETARGET_SCRIPT_PATH environment variable
+    2. Local BlenderTools/dev/ directory
+    """
+    # Check environment variable first
+    env_path = os.environ.get("RETARGET_SCRIPT_PATH")
+    if env_path and Path(env_path).exists():
+        return Path(env_path)
+
     # Check local BlenderTools
     script_path = BLENDER_TOOLS_DIR / "dev" / "retarget_script2_14.py"
     if script_path.exists():
         return script_path
 
-    # Check external location
-    external_path = Path(r"D:\vrchat\mao_avator - mochifitter\BlenderTools\blender-4.0.2-windows-x64\dev\retarget_script2_14.py")
-    if external_path.exists():
-        return external_path
-
-    raise FileNotFoundError(f"retarget_script2_14.py not found at {script_path}")
+    raise FileNotFoundError(
+        f"retarget_script2_14.py not found. "
+        f"Set RETARGET_SCRIPT_PATH environment variable or place script at {script_path}"
+    )
 
 
 def resolve_path(path: str) -> Path:


### PR DESCRIPTION
## 概要

- `run_retarget.py` から開発者固有のハードコードパスを削除
- 環境変数サポートを追加し柔軟な設定を可能に
- READMEにセットアップ手順を追記

## 変更内容

### パス処理の改善
- `find_blender()` から `D:\vrchat\...` のハードコードパスを削除
- `find_retarget_script()` から外部ハードコードパスを削除
- `RETARGET_SCRIPT_PATH` 環境変数サポートを追加
- Blender 4.3 を一般パスに追加

### ドキュメント
- 環境変数設定手順を追加 (PowerShell/CMD)
- CLIラッパーの使用方法を追記

## 環境変数

| 変数 | 説明 |
|------|------|
| `BLENDER_PATH` | Blender実行ファイルのパス |
| `RETARGET_SCRIPT_PATH` | retarget_script2_14.py のパス |

## ベンチマーク結果 (前回テストより)

| 項目 | 値 |
|------|-----|
| 処理時間 | 287.62秒 (~4.8分) |
| 出力ファイル | cli_test_beryl_to_mao.fbx |
| サイズ | 4.53 MB |
| ステータス | ✅ 成功 |

## テスト計画

- [ ] 環境変数を設定して `python run_retarget.py --preset beryl_to_mao` を実行
- [ ] BLENDER_PATH 経由でBlenderが検出されることを確認
- [ ] RETARGET_SCRIPT_PATH 経由でスクリプトが検出されることを確認

Refs #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)