### PR TITLE
fix(unity-addon): シェイプキー削除後のデータ整合性を確保

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `_deformation_field_cache` (NPZデータ、KDTree) の適切な解放
   - `bpy.data.orphans_purge()` による Blender 孤立データの解放
   - `gc.collect()` によるガベージコレクション強制実行
+- **Unity アドオン**: シェイプキー削除後のデータ整合性を確保 (Issue #46)
+  - `obj.data.update()` を追加（シェイプキー削除後のメッシュデータ同期）
+  - `bpy.context.view_layer.update()` を追加（依存グラフ更新）
+  - `evaluated_get()` が正しいデータを返すことを保証
+  - 参照: [Blender #115572](https://projects.blender.org/blender/blender/issues/115572)
 
 ## [0.2.17] - 2025-12-29
 

--- a/MochFitter-unity-addon/BlenderTools/blender-4.0.2-windows-x64/dev/retarget_script2_14.py
+++ b/MochFitter-unity-addon/BlenderTools/blender-4.0.2-windows-x64/dev/retarget_script2_14.py
@@ -19557,6 +19557,7 @@ def process_mesh_in_cycle1(
                 # generatedシェイプキーを削除
                 obj.shape_key_remove(generated_key)
                 print(f"Removed generated shape key: {generated_name} from {obj.name}")
+                obj.data.update()  # シェイプキー削除後のメッシュデータ整合性を確保
 
     print(f"  {obj.name}の処理: {time.time() - obj_start:.2f}秒")
 
@@ -19931,11 +19932,17 @@ def process_single_config(args, config_pair, pair_index, total_pairs, overall_st
         cycle1_end = time.time()
         print(f"サイクル1全体: {cycle1_end - cycle1_start:.2f}秒")
 
+        # Cycle1完了後、依存グラフを更新して evaluated_get() が正しいデータを返すことを保証
+        bpy.context.view_layer.update()
+
         for obj in clothing_meshes:
             if obj.data.shape_keys:
                 for key_block in obj.data.shape_keys.key_blocks:
                     print(f"Shape key: {key_block.name} / {key_block.value} found on {obj.name}")
-        
+
+        # duplicate_mesh_with_partial_weights 呼び出し前に依存グラフを再更新
+        bpy.context.view_layer.update()
+
         right_base_mesh, left_base_mesh = duplicate_mesh_with_partial_weights(base_mesh, base_avatar_data)
         duplicate_time = time.time()
         print(f"ベースメッシュ複製: {duplicate_time - cycle1_end:.2f}秒")


### PR DESCRIPTION
## Summary

- もちふぃった～開発者からのフィードバックに基づき、シェイプキー削除後のデータ整合性を確保する修正を追加
- `obj.data.update()` と `bpy.context.view_layer.update()` を適切な箇所に追加
- `evaluated_get()` が常に最新のデータを返すことを保証

## 修正内容

### 1. `process_mesh_in_cycle1()` 内

```python
obj.shape_key_remove(generated_key)
print(f"Removed generated shape key: {generated_name} from {obj.name}")
obj.data.update()  # 追加: シェイプキー削除後のメッシュデータ同期
```

### 2. `process_single_config()` 内（Cycle1完了後）

```python
cycle1_end = time.time()
print(f"サイクル1全体: {cycle1_end - cycle1_start:.2f}秒")

# 追加: Cycle1完了後、依存グラフを更新
bpy.context.view_layer.update()

for obj in clothing_meshes:
    ...

# 追加: duplicate_mesh_with_partial_weights 呼び出し前に依存グラフを再更新
bpy.context.view_layer.update()

right_base_mesh, left_base_mesh = duplicate_mesh_with_partial_weights(...)
```

## 背景

- PR #35 で `clear_all_caches()` + `gc.collect()` によるメモリ管理を実装済み
- しかし、`gc.collect()` は Python GC であり、Blender コア側のメッシュデータ整合性には効果がない
- シェイプキー削除後、依存グラフが古い状態のまま次の処理に進むと、クラッシュや未定義動作が発生する可能性がある

## 根拠

- [Blender #115572](https://projects.blender.org/blender/blender/issues/115572): `shape_key_remove()` 後の法線破損問題
  - ワークアラウンド: `mesh.update()` を呼ぶ
- [Depsgraph API ドキュメント](https://docs.blender.org/api/current/bpy.types.Depsgraph.html)
  - `evaluated_depsgraph_get()` は依存グラフが完全に評価されていることを保証
  - 変更後に更新しないと、古いポインタが露出する可能性

## Test plan

- [ ] Beryl → Template → mao チェーン処理で OOM が発生しないことを確認
- [ ] シェイプキー削除後の処理でクラッシュしないことを確認
- [ ] 出力 FBX が正常であることを確認

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)