### PR TITLE
fix(unity-addon): remove unnecessary numpy-to-Vector conversion in inverse_bone_deform_all_vertices

### DIFF
--- a/MochFitter-unity-addon/BlenderTools/blender-4.0.2-windows-x64/dev/retarget_script2_14.py
+++ b/MochFitter-unity-addon/BlenderTools/blender-4.0.2-windows-x64/dev/retarget_script2_14.py
@@ -6103,10 +6103,10 @@ def inverse_bone_deform_all_vertices(armature_obj, mesh_obj):
         raise ValueError("有効なメッシュオブジェクトを指定してください")
 
     # ワールド座標に変換（変形後の頂点位置）
-    vertices_np = get_mesh_vertices_foreach(mesh_obj.data).copy()
-
-    # numpy配列をVectorリストに一括変換（ループ内変換より高速）
-    vertices = [Vector(v) for v in vertices_np]
+    # NOTE: この関数では foreach_get を使わず、直接 Vector を取得する。
+    # 理由: 後続の Matrix @ Vector 演算に Vector 型が必要であり、
+    # foreach_get → numpy → Vector 変換はオーバーヘッドが大きい。
+    vertices = [v.co.copy() for v in mesh_obj.data.vertices]
 
     # 結果を格納するリスト
     inverse_transformed_vertices = []


### PR DESCRIPTION
## Summary

`inverse_bone_deform_all_vertices()` 関数で不要な numpy → Vector 変換を削除。

## 変更内容

**Before:**
```python
vertices_np = get_mesh_vertices_foreach(mesh_obj.data).copy()
vertices = [Vector(v) for v in vertices_np]
```

**After:**
```python
vertices = [v.co.copy() for v in mesh_obj.data.vertices]
```

## 背景

Issue #48 の調査で、オリジナル MochiFitter（265.32秒）と比較して Phase 1 最適化版（293.97秒）が **+10.8% 遅い** ことが判明。

原因の一つとして `inverse_bone_deform_all_vertices()` での以下の処理が特定された：
1. `foreach_get` で numpy 配列を取得
2. numpy 配列を Vector リストに変換
3. Matrix @ Vector 演算を実行

この関数では結局 Vector が必要なため、foreach_get を経由する意味がない。

## ベンチマーク結果

| バージョン | 平均処理時間 | 備考 |
|-----------|-------------|------|
| オリジナル（#48前） | 265.32秒 | 真のベースライン |
| Phase 1 完了（修正前） | 293.97秒 | +10.8% 回帰 |
| **この PR 適用後** | **295.14秒** | **改善なし** |

### 考察

E2E ベンチマークでは有意な改善が見られませんでした。これは：

1. **この関数がボトルネックではない**: `inverse_bone_deform_all_vertices()` の処理時間は全体の一部
2. **他の要因が支配的**: リファクタリング（PR #38-#47）で追加された処理が影響している可能性
3. **オリジナルとの差（~30秒）の主因は別の場所にある**

## この PR の価値

E2E で改善は見られませんが、以下の理由でマージを推奨：

- ✅ 不要な中間変換を削除（コードの明確化）
- ✅ オリジナル MochiFitter の実装と整合
- ✅ 将来の最適化のための基盤整理

## 次のアクション提案

1. **リファクタリング PRs（#38-#47）のオーバーヘッド調査**
2. **処理フェーズ別のプロファイリング実施**
3. **Numba インストール環境での P1-2 効果測定**

## Test plan

- [x] E2E テスト: Beryl → Template → mao（成功、295.14秒平均）
- [x] 構文チェック: `python -m py_compile` 通過
- [x] 出力 FBX: 4.53 MB（正常）

Refs #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)