### PR TITLE
perf(unity-addon): query_ball_point batch optimization analysis

### DIFF
--- a/tests/profile_smoothing_processor.py
+++ b/tests/profile_smoothing_processor.py
@@ -1,0 +1,366 @@
+"""
+smoothing_processor.py のプロファイリングスクリプト
+
+現在の実装と最適化案の性能を比較測定する
+"""
+
+import numpy as np
+import time
+import sys
+import os
+from scipy.spatial import cKDTree
+from typing import List, Tuple, Dict
+import cProfile
+import pstats
+from io import StringIO
+
+# テストパラメータ（実際の使用状況に近い値）
+TEST_VERTEX_COUNT = 25000  # 典型的なメッシュの頂点数
+TEST_GROUP_COUNT = 40      # 頂点グループ数
+SMOOTHING_RADIUS = 0.02    # スムージング半径
+ITERATION_COUNT = 3        # イテレーション回数
+
+
+def generate_test_data(num_vertices: int, num_groups: int) -> Tuple[np.ndarray, List[np.ndarray], np.ndarray]:
+    """テスト用のデータを生成"""
+    np.random.seed(42)
+
+    # 頂点座標（単位立方体内にランダム分布）
+    vertex_coords = np.random.rand(num_vertices, 3).astype(np.float32)
+
+    # 頂点グループのウェイト（各グループにランダムなウェイト）
+    group_weights = []
+    for _ in range(num_groups):
+        weights = np.random.rand(num_vertices).astype(np.float32)
+        # 約50%の頂点をゼロに
+        weights[np.random.rand(num_vertices) < 0.5] = 0
+        group_weights.append(weights)
+
+    # マスクウェイト
+    mask_weights = np.random.rand(num_vertices).astype(np.float32)
+
+    return vertex_coords, group_weights, mask_weights
+
+
+# ============================================================
+# 現在の実装（smoothing_processor.py から抽出）
+# ============================================================
+
+def gaussian_weights(distances, sigma):
+    """ガウシアン減衰による重み計算"""
+    return np.exp(-(distances ** 2) / (2 * sigma ** 2))
+
+
+def current_apply_smoothing_sequential(vertex_coords, current_weights, kdtree,
+                                        smoothing_radius, sigma):
+    """現在の実装: 頂点ごとのループ"""
+    num_vertices = len(vertex_coords)
+    smoothed_weights = np.zeros(num_vertices, dtype=np.float32)
+
+    for i in range(num_vertices):
+        neighbor_indices = kdtree.query_ball_point(vertex_coords[i], smoothing_radius)
+
+        if len(neighbor_indices) > 1:
+            neighbor_indices = np.asarray(neighbor_indices, dtype=np.int32)
+            neighbor_coords = vertex_coords[neighbor_indices]
+            distances = np.linalg.norm(neighbor_coords - vertex_coords[i], axis=1)
+            neighbor_weights = current_weights[neighbor_indices]
+
+            weights = gaussian_weights(distances, sigma)
+            weights_sum = np.sum(weights)
+            if weights_sum > 0.001:
+                smoothed_weights[i] = neighbor_weights @ weights / weights_sum
+            else:
+                smoothed_weights[i] = current_weights[i]
+        else:
+            smoothed_weights[i] = current_weights[i]
+
+    return smoothed_weights
+
+
+def current_mask_blending(original_weights, smoothed_weights, mask_weights):
+    """現在の実装: Python for ループによるマスク合成"""
+    num_vertices = len(original_weights)
+    final_weights = np.zeros(num_vertices, dtype=np.float32)
+
+    for i in range(num_vertices):
+        blend_factor = mask_weights[i]
+        final_weights[i] = original_weights[i] * (1.0 - blend_factor) + smoothed_weights[i] * blend_factor
+
+    return final_weights
+
+
+# ============================================================
+# 最適化案
+# ============================================================
+
+def optimized_apply_smoothing_batch(vertex_coords, current_weights, kdtree,
+                                     smoothing_radius, sigma):
+    """最適化案: query_ball_point を一括呼び出し"""
+    num_vertices = len(vertex_coords)
+    smoothed_weights = np.zeros(num_vertices, dtype=np.float32)
+
+    # 全頂点の近傍を一括取得
+    all_neighbors = kdtree.query_ball_point(vertex_coords, smoothing_radius)
+
+    for i in range(num_vertices):
+        neighbor_indices = all_neighbors[i]
+
+        if len(neighbor_indices) > 1:
+            neighbor_indices = np.asarray(neighbor_indices, dtype=np.int32)
+            neighbor_coords = vertex_coords[neighbor_indices]
+            distances = np.linalg.norm(neighbor_coords - vertex_coords[i], axis=1)
+            neighbor_weights = current_weights[neighbor_indices]
+
+            weights = gaussian_weights(distances, sigma)
+            weights_sum = np.sum(weights)
+            if weights_sum > 0.001:
+                smoothed_weights[i] = neighbor_weights @ weights / weights_sum
+            else:
+                smoothed_weights[i] = current_weights[i]
+        else:
+            smoothed_weights[i] = current_weights[i]
+
+    return smoothed_weights
+
+
+def optimized_mask_blending(original_weights, smoothed_weights, mask_weights):
+    """最適化案: NumPy ベクトル化によるマスク合成"""
+    return original_weights * (1.0 - mask_weights) + smoothed_weights * mask_weights
+
+
+# ============================================================
+# プロファイリング関数
+# ============================================================
+
+def profile_kdtree_construction(vertex_coords: np.ndarray, num_iterations: int = 10) -> float:
+    """KDTree 構築時間を計測"""
+    times = []
+    for _ in range(num_iterations):
+        start = time.perf_counter()
+        kdtree = cKDTree(vertex_coords)
+        times.append(time.perf_counter() - start)
+    return np.mean(times)
+
+
+def profile_query_ball_point_loop(vertex_coords: np.ndarray, kdtree: cKDTree,
+                                   radius: float, num_iterations: int = 3) -> float:
+    """頂点ごとの query_ball_point 時間を計測"""
+    times = []
+    for _ in range(num_iterations):
+        start = time.perf_counter()
+        for i in range(len(vertex_coords)):
+            neighbors = kdtree.query_ball_point(vertex_coords[i], radius)
+        times.append(time.perf_counter() - start)
+    return np.mean(times)
+
+
+def profile_query_ball_point_batch(vertex_coords: np.ndarray, kdtree: cKDTree,
+                                    radius: float, num_iterations: int = 3) -> float:
+    """一括 query_ball_point 時間を計測"""
+    times = []
+    for _ in range(num_iterations):
+        start = time.perf_counter()
+        all_neighbors = kdtree.query_ball_point(vertex_coords, radius)
+        times.append(time.perf_counter() - start)
+    return np.mean(times)
+
+
+def profile_smoothing_iteration(vertex_coords: np.ndarray, weights: np.ndarray,
+                                 smoothing_radius: float, use_batch: bool = False) -> Tuple[float, float]:
+    """スムージング1イテレーションの時間を計測（KDTree構築含む）"""
+    sigma = smoothing_radius / 3.0
+
+    # KDTree 構築
+    kdtree_start = time.perf_counter()
+    kdtree = cKDTree(vertex_coords)
+    kdtree_time = time.perf_counter() - kdtree_start
+
+    # スムージング
+    smoothing_start = time.perf_counter()
+    if use_batch:
+        result = optimized_apply_smoothing_batch(vertex_coords, weights, kdtree, smoothing_radius, sigma)
+    else:
+        result = current_apply_smoothing_sequential(vertex_coords, weights, kdtree, smoothing_radius, sigma)
+    smoothing_time = time.perf_counter() - smoothing_start
+
+    return kdtree_time, smoothing_time
+
+
+def profile_mask_blending(original: np.ndarray, smoothed: np.ndarray,
+                          mask: np.ndarray, num_iterations: int = 100) -> Tuple[float, float]:
+    """マスク合成の時間を計測"""
+    # 現在の実装
+    times_current = []
+    for _ in range(num_iterations):
+        start = time.perf_counter()
+        result = current_mask_blending(original, smoothed, mask)
+        times_current.append(time.perf_counter() - start)
+
+    # 最適化版
+    times_optimized = []
+    for _ in range(num_iterations):
+        start = time.perf_counter()
+        result = optimized_mask_blending(original, smoothed, mask)
+        times_optimized.append(time.perf_counter() - start)
+
+    return np.mean(times_current), np.mean(times_optimized)
+
+
+def run_full_profile():
+    """完全なプロファイリングを実行"""
+    print("=" * 70)
+    print("smoothing_processor.py プロファイリング")
+    print("=" * 70)
+    print(f"\nテストパラメータ:")
+    print(f"  頂点数: {TEST_VERTEX_COUNT:,}")
+    print(f"  グループ数: {TEST_GROUP_COUNT}")
+    print(f"  スムージング半径: {SMOOTHING_RADIUS}")
+    print(f"  イテレーション数: {ITERATION_COUNT}")
+
+    # テストデータ生成
+    print("\nテストデータ生成中...")
+    vertex_coords, group_weights, mask_weights = generate_test_data(TEST_VERTEX_COUNT, TEST_GROUP_COUNT)
+
+    # KDTree 構築
+    print("\n" + "-" * 70)
+    print("1. KDTree 構築時間")
+    print("-" * 70)
+    kdtree_time = profile_kdtree_construction(vertex_coords)
+    print(f"  1回あたり: {kdtree_time*1000:.2f} ms")
+    print(f"  グループ数分 ({TEST_GROUP_COUNT}回): {kdtree_time*TEST_GROUP_COUNT*1000:.2f} ms")
+    print(f"  → KDTree再利用で削減可能: {kdtree_time*(TEST_GROUP_COUNT-1)*1000:.2f} ms")
+
+    # KDTree を事前構築
+    kdtree = cKDTree(vertex_coords)
+
+    # query_ball_point 比較
+    print("\n" + "-" * 70)
+    print("2. query_ball_point 比較")
+    print("-" * 70)
+    loop_time = profile_query_ball_point_loop(vertex_coords, kdtree, SMOOTHING_RADIUS, num_iterations=1)
+    batch_time = profile_query_ball_point_batch(vertex_coords, kdtree, SMOOTHING_RADIUS, num_iterations=3)
+    print(f"  ループ版 (現在):  {loop_time*1000:.2f} ms")
+    print(f"  バッチ版 (最適化): {batch_time*1000:.2f} ms")
+    print(f"  → 改善率: {(loop_time - batch_time) / loop_time * 100:.1f}%")
+    print(f"  → 削減時間: {(loop_time - batch_time)*1000:.2f} ms/イテレーション")
+
+    # スムージング全体（1グループ、1イテレーション）
+    print("\n" + "-" * 70)
+    print("3. スムージング全体 (1グループ, 1イテレーション)")
+    print("-" * 70)
+
+    test_weights = group_weights[0]
+
+    # 現在の実装
+    kd_time_curr, smooth_time_curr = profile_smoothing_iteration(
+        vertex_coords, test_weights, SMOOTHING_RADIUS, use_batch=False)
+    total_curr = kd_time_curr + smooth_time_curr
+
+    # 最適化版
+    kd_time_opt, smooth_time_opt = profile_smoothing_iteration(
+        vertex_coords, test_weights, SMOOTHING_RADIUS, use_batch=True)
+    total_opt = kd_time_opt + smooth_time_opt
+
+    print(f"  現在の実装:")
+    print(f"    KDTree構築: {kd_time_curr*1000:.2f} ms")
+    print(f"    スムージング: {smooth_time_curr*1000:.2f} ms")
+    print(f"    合計: {total_curr*1000:.2f} ms")
+    print(f"  最適化版:")
+    print(f"    KDTree構築: {kd_time_opt*1000:.2f} ms")
+    print(f"    スムージング: {smooth_time_opt*1000:.2f} ms")
+    print(f"    合計: {total_opt*1000:.2f} ms")
+    print(f"  → 改善率: {(total_curr - total_opt) / total_curr * 100:.1f}%")
+
+    # マスク合成
+    print("\n" + "-" * 70)
+    print("4. マスク合成 (全グループ分)")
+    print("-" * 70)
+
+    smoothed = np.random.rand(TEST_VERTEX_COUNT).astype(np.float32)
+    original = test_weights
+
+    mask_current, mask_optimized = profile_mask_blending(original, smoothed, mask_weights)
+    print(f"  現在 (for loop): {mask_current*1000:.4f} ms × {TEST_GROUP_COUNT} = {mask_current*1000*TEST_GROUP_COUNT:.2f} ms")
+    print(f"  最適化 (NumPy):  {mask_optimized*1000:.4f} ms × {TEST_GROUP_COUNT} = {mask_optimized*1000*TEST_GROUP_COUNT:.2f} ms")
+    print(f"  → 削減時間: {(mask_current - mask_optimized)*1000*TEST_GROUP_COUNT:.2f} ms")
+
+    # 全体の見積もり
+    print("\n" + "=" * 70)
+    print("5. 全体削減見積もり (subprocess 1回あたり)")
+    print("=" * 70)
+
+    # 現在の推定時間
+    # グループあたり: KDTree構築 + iteration回のスムージング
+    current_per_group = kdtree_time + (smooth_time_curr * ITERATION_COUNT)
+    current_total = current_per_group * TEST_GROUP_COUNT + (mask_current * TEST_GROUP_COUNT)
+
+    # 最適化後の推定時間
+    # KDTree 1回 + グループあたり iteration回のスムージング（バッチ版）
+    optimized_total = kdtree_time + (smooth_time_opt * ITERATION_COUNT * TEST_GROUP_COUNT) + (mask_optimized * TEST_GROUP_COUNT)
+
+    print(f"\n  現在の実装 (推定):")
+    print(f"    KDTree構築: {kdtree_time*1000:.2f} ms × {TEST_GROUP_COUNT} = {kdtree_time*1000*TEST_GROUP_COUNT:.2f} ms")
+    print(f"    スムージング: {smooth_time_curr*1000:.2f} ms × {ITERATION_COUNT} × {TEST_GROUP_COUNT} = {smooth_time_curr*1000*ITERATION_COUNT*TEST_GROUP_COUNT:.2f} ms")
+    print(f"    マスク合成: {mask_current*1000*TEST_GROUP_COUNT:.2f} ms")
+    print(f"    合計: {current_total*1000:.2f} ms ({current_total:.2f} 秒)")
+
+    print(f"\n  最適化版 (推定):")
+    print(f"    KDTree構築: {kdtree_time*1000:.2f} ms × 1 = {kdtree_time*1000:.2f} ms (再利用)")
+    print(f"    スムージング: {smooth_time_opt*1000:.2f} ms × {ITERATION_COUNT} × {TEST_GROUP_COUNT} = {smooth_time_opt*1000*ITERATION_COUNT*TEST_GROUP_COUNT:.2f} ms")
+    print(f"    マスク合成: {mask_optimized*1000*TEST_GROUP_COUNT:.2f} ms")
+    print(f"    合計: {optimized_total*1000:.2f} ms ({optimized_total:.2f} 秒)")
+
+    reduction = current_total - optimized_total
+    reduction_percent = (reduction / current_total) * 100
+
+    print(f"\n  削減見積もり:")
+    print(f"    削減時間: {reduction*1000:.2f} ms ({reduction:.2f} 秒)")
+    print(f"    削減率: {reduction_percent:.1f}%")
+
+    # 実際の subprocess 呼び出し回数を考慮
+    print("\n" + "=" * 70)
+    print("6. 実運用での削減見積もり")
+    print("=" * 70)
+
+    # ベンチマークから: smoothing 処理は2ペアで4回呼ばれる（各メッシュで1回ずつ、2ペア）
+    # 実際にはもっと多いかもしれないが、保守的に見積もる
+    subprocess_calls = 4  # 保守的な見積もり
+
+    print(f"\n  subprocess 呼び出し回数 (推定): {subprocess_calls}")
+    print(f"  1回あたりの削減: {reduction:.2f} 秒")
+    print(f"  合計削減時間: {reduction * subprocess_calls:.2f} 秒")
+
+    return {
+        'kdtree_time': kdtree_time,
+        'loop_time': loop_time,
+        'batch_time': batch_time,
+        'smooth_time_curr': smooth_time_curr,
+        'smooth_time_opt': smooth_time_opt,
+        'mask_current': mask_current,
+        'mask_optimized': mask_optimized,
+        'current_total': current_total,
+        'optimized_total': optimized_total,
+        'reduction': reduction,
+        'reduction_percent': reduction_percent
+    }
+
+
+if __name__ == '__main__':
+    results = run_full_profile()
+
+    print("\n" + "=" * 70)
+    print("結論")
+    print("=" * 70)
+    print(f"""
+現実的な削減見積もり:
+
+  楽観的シナリオ: {results['reduction'] * 6:.1f} 秒 (6回の subprocess 呼び出し想定)
+  現実的シナリオ: {results['reduction'] * 4:.1f} 秒 (4回の subprocess 呼び出し想定)
+  保守的シナリオ: {results['reduction'] * 2:.1f} 秒 (2回の subprocess 呼び出し想定)
+
+主な改善ポイント:
+  1. query_ball_point 一括化: {(results['loop_time'] - results['batch_time'])*1000:.1f} ms/イテレーション削減
+  2. KDTree 再利用: {results['kdtree_time']*1000*(TEST_GROUP_COUNT-1):.1f} ms 削減
+  3. マスク合成ベクトル化: {(results['mask_current'] - results['mask_optimized'])*1000*TEST_GROUP_COUNT:.2f} ms 削減
+""")

--- a/tests/test_smoothing_optimization.py
+++ b/tests/test_smoothing_optimization.py
@@ -1,0 +1,187 @@
+"""
+smoothing_processor.py の最適化テスト
+
+バッチクエリと従来のループ版の結果が一致することを確認
+"""
+
+import numpy as np
+import sys
+import os
+import time
+
+# smoothing_processor.py をインポート
+sys.path.insert(0, os.path.join(os.path.dirname(__file__),
+    '..', 'MochFitter-unity-addon', 'OutfitRetargetingSystem', 'Editor'))
+
+from smoothing_processor import (
+    apply_smoothing_sequential,
+    query_neighbors_batched,
+    blend_weights_vectorized,
+    BATCH_QUERY_CHUNK_SIZE
+)
+from scipy.spatial import cKDTree
+
+
+def test_query_neighbors_batched():
+    """query_neighbors_batched が正しく動作することを確認"""
+    print("=" * 60)
+    print("Test 1: query_neighbors_batched")
+    print("=" * 60)
+
+    np.random.seed(42)
+    num_vertices = 5000
+    vertex_coords = np.random.rand(num_vertices, 3).astype(np.float32)
+    radius = 0.05
+
+    kdtree = cKDTree(vertex_coords)
+
+    # 従来方式
+    loop_start = time.perf_counter()
+    loop_neighbors = []
+    for i in range(num_vertices):
+        neighbors = kdtree.query_ball_point(vertex_coords[i], radius)
+        loop_neighbors.append(neighbors)
+    loop_time = time.perf_counter() - loop_start
+
+    # バッチ方式
+    batch_start = time.perf_counter()
+    batch_neighbors = query_neighbors_batched(vertex_coords, kdtree, radius)
+    batch_time = time.perf_counter() - batch_start
+
+    # 結果を比較
+    match = True
+    for i in range(num_vertices):
+        if set(loop_neighbors[i]) != set(batch_neighbors[i]):
+            print(f"  Mismatch at vertex {i}")
+            match = False
+            break
+
+    print(f"  頂点数: {num_vertices}")
+    print(f"  ループ版: {loop_time*1000:.2f} ms")
+    print(f"  バッチ版: {batch_time*1000:.2f} ms")
+    print(f"  高速化: {loop_time/batch_time:.2f}x")
+    print(f"  結果一致: {'OK' if match else 'NG'}")
+
+    return match
+
+
+def test_apply_smoothing_sequential():
+    """apply_smoothing_sequential のバッチ/非バッチ結果が一致することを確認"""
+    print("\n" + "=" * 60)
+    print("Test 2: apply_smoothing_sequential (batch vs loop)")
+    print("=" * 60)
+
+    np.random.seed(42)
+    num_vertices = 3000
+    vertex_coords = np.random.rand(num_vertices, 3).astype(np.float32)
+    weights = np.random.rand(num_vertices).astype(np.float32)
+    radius = 0.05
+
+    kdtree = cKDTree(vertex_coords)
+
+    # 従来方式 (use_batch_query=False)
+    loop_start = time.perf_counter()
+    loop_result = apply_smoothing_sequential(
+        vertex_coords, weights, kdtree, radius,
+        use_distance_weighting=True, gaussian_falloff=True,
+        use_batch_query=False
+    )
+    loop_time = time.perf_counter() - loop_start
+
+    # バッチ方式 (use_batch_query=True)
+    batch_start = time.perf_counter()
+    batch_result = apply_smoothing_sequential(
+        vertex_coords, weights, kdtree, radius,
+        use_distance_weighting=True, gaussian_falloff=True,
+        use_batch_query=True
+    )
+    batch_time = time.perf_counter() - batch_start
+
+    # 結果を比較
+    max_diff = np.max(np.abs(loop_result - batch_result))
+    match = max_diff < 1e-6
+
+    print(f"  頂点数: {num_vertices}")
+    print(f"  ループ版: {loop_time*1000:.2f} ms")
+    print(f"  バッチ版: {batch_time*1000:.2f} ms")
+    print(f"  高速化: {loop_time/batch_time:.2f}x")
+    print(f"  最大差分: {max_diff:.2e}")
+    print(f"  結果一致: {'OK' if match else 'NG'}")
+
+    return match
+
+
+def test_blend_weights_vectorized():
+    """blend_weights_vectorized が従来のループと同じ結果を返すことを確認"""
+    print("\n" + "=" * 60)
+    print("Test 3: blend_weights_vectorized")
+    print("=" * 60)
+
+    np.random.seed(42)
+    num_vertices = 10000
+    original = np.random.rand(num_vertices).astype(np.float32)
+    smoothed = np.random.rand(num_vertices).astype(np.float32)
+    mask = np.random.rand(num_vertices).astype(np.float32)
+
+    # 従来方式
+    loop_start = time.perf_counter()
+    loop_result = np.zeros(num_vertices, dtype=np.float32)
+    for i in range(num_vertices):
+        blend_factor = mask[i]
+        loop_result[i] = original[i] * (1.0 - blend_factor) + smoothed[i] * blend_factor
+    loop_time = time.perf_counter() - loop_start
+
+    # ベクトル化版
+    vec_start = time.perf_counter()
+    vec_result = blend_weights_vectorized(original, smoothed, mask)
+    vec_time = time.perf_counter() - vec_start
+
+    # 結果を比較
+    max_diff = np.max(np.abs(loop_result - vec_result))
+    match = max_diff < 1e-6
+
+    print(f"  頂点数: {num_vertices}")
+    print(f"  ループ版: {loop_time*1000:.4f} ms")
+    print(f"  ベクトル版: {vec_time*1000:.4f} ms")
+    print(f"  高速化: {loop_time/vec_time:.0f}x")
+    print(f"  最大差分: {max_diff:.2e}")
+    print(f"  結果一致: {'OK' if match else 'NG'}")
+
+    return match
+
+
+def run_all_tests():
+    """すべてのテストを実行"""
+    print("\n" + "=" * 60)
+    print("smoothing_processor.py 最適化テスト")
+    print("=" * 60 + "\n")
+
+    results = []
+    results.append(("query_neighbors_batched", test_query_neighbors_batched()))
+    results.append(("apply_smoothing_sequential", test_apply_smoothing_sequential()))
+    results.append(("blend_weights_vectorized", test_blend_weights_vectorized()))
+
+    print("\n" + "=" * 60)
+    print("テスト結果サマリー")
+    print("=" * 60)
+
+    all_passed = True
+    for name, passed in results:
+        status = "PASS" if passed else "FAIL"
+        print(f"  {name}: {status}")
+        if not passed:
+            all_passed = False
+
+    print("\n" + "=" * 60)
+    if all_passed:
+        print("すべてのテストが成功しました！")
+    else:
+        print("一部のテストが失敗しました。")
+    print("=" * 60)
+
+    return all_passed
+
+
+if __name__ == '__main__':
+    success = run_all_tests()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## 概要

`smoothing_processor.py` の `query_ball_point` バッチ最適化を調査した結果、
**単体テストでは高速化を確認したが、E2Eベンチマークでは回帰が発生**しました。

この PR は原因解析のためのレビューを依頼するものです。

---

## 調査内容

### 最適化手法

```python
# 従来: 頂点ごとにループ
for i in range(num_vertices):
    neighbors = kdtree.query_ball_point(vertex_coords[i], radius)

# 最適化: 全頂点を一括処理（チャンク分割）
all_neighbors = kdtree.query_ball_point(vertex_coords, radius)
```

---

## テスト結果

### 単体テスト（PASS）

| テスト | 高速化 |
|--------|--------|
| query_neighbors_batched | 4.01x |
| apply_smoothing_sequential | 1.71x |
| blend_weights_vectorized | 227x |

### E2Eベンチマーク（REGRESSION）

| モード | 処理時間 |
|--------|----------|
| バッチ無効 | **179.85秒** |
| バッチ有効 | 244.81秒 |

**65秒の回帰**

---

## 仮説

1. **メモリオーバーヘッド**: バッチクエリは全頂点の近傍リストを一度に生成
2. **Python オブジェクトコスト**: `List[List[int]]` の生成・拡張コスト
3. **ワーカー間の競合**: multiprocessing.Pool 内での同時メモリ割り当て

---

## gitignore されたファイルの変更

`smoothing_processor.py` は gitignore されているため、この PR には含まれていません。
変更内容：

```python
# 追加した関数
def query_neighbors_batched(vertex_coords, kdtree, radius, chunk_size=10000):
    """メモリ効率を考慮したバッチ近傍検索"""
    ...

def blend_weights_vectorized(original_weights, smoothed_weights, mask_weights):
    """NumPyベクトル演算によるウェイト合成"""
    ...

# 変更した関数
def apply_smoothing_sequential(..., use_batch_query=False):  # デフォルト無効
    if use_batch_query:
        all_neighbors = query_neighbors_batched(...)
    ...
```

---

## レビュー依頼事項

1. **回帰の根本原因の特定**
   - 単体テストと E2E で挙動が異なる理由
   - multiprocessing 環境での追加オーバーヘッド

2. **改善の可能性**
   - より効率的なバッチ処理の方法
   - メモリ使用量を抑えた実装

3. **判断**
   - この最適化を追求する価値があるか
   - 他のアプローチを検討すべきか

---

## 関連

- Issue #48: CPU最適化による処理高速化
- [プロファイリング結果](https://github.com/Mega-Gorilla/MochiFitter-BlenderAddon-kai/issues/48#issuecomment-3703900089)

🤖 Generated with [Claude Code](https://claude.com/claude-code)