### PR TITLE
fix(unity-addon): add post-transfer L/R weight swap correction for center-line vertices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - コメントアウトコードの削除
 
 ### Fixed
-- **Unity アドオン**: 最適化版で中心線上頂点の左右ウェイトが入れ替わる問題を修正 (Issue #60, PR #61)
-  - `temporarily_merge_for_weight_transfer` で `query_ball_point` による完全なタイブレーク方式を採用
-  - 同距離の全候補を取得し、最小インデックスを選択（3点以上の同距離ケースにも対応）
+- **Unity アドオン**: 最適化版で中心線上頂点の左右ウェイトが入れ替わる問題を修正 (Issue #60, PR #61, PR #62)
+  - `temporarily_merge_for_weight_transfer` で `query_ball_point` による完全なタイブレーク方式を採用 (PR #61)
+  - `fix_centerline_lr_weight_swaps()` による後処理修正を追加 (PR #62)
+    - 外部アドオン (robust_weight_transfer) のKDTreeタイブレーク問題を回避
+    - 頂点のX座標に基づいて不適切なL/Rウェイト割り当てを検出・修正
   - 原因: cKDTree のタイブレーク動作が不定で、中心線上 (X≈0) の頂点が反対側のソース頂点とマッチする可能性があった
-  - **注意**: `process_weight_transfer_with_component_normalization` の修正は別PRで対応予定
 - **Unity アドオン**: チェーン処理時のメモリ不足クラッシュを修正 (Issue #34, PR #35)
   - `clear_all_caches()` 関数を追加（全グローバルキャッシュのクリア）
   - ペア処理間でキャッシュクリアを実行


### PR DESCRIPTION
## Summary

外部アドオン（robust_weight_transfer）のKDTreeタイブレーク問題による、中心線頂点のL/Rウェイトスワップを修正します。

This PR adds a post-processing fix for L/R weight swaps that occur during weight transfer using the external robust_weight_transfer addon.

## Problem

The robust_weight_transfer addon (`bpy.ops.object.skin_weight_transfer()`) uses its own internal KDTree for nearest-neighbor search. For center-line vertices (X≈0) on the clothing mesh, which are equidistant from both left and right body vertices, the KDTree's non-deterministic tie-breaking can cause:

- Vertices at X > 0 (left side) to receive Right bone weights
- Vertices at X < 0 (right side) to receive Left bone weights

## Solution

Added `fix_centerline_lr_weight_swaps()` function that runs after the L/R weight transfers complete:

1. Builds a list of L/R bone pairs (e.g., Butt_L/Butt_R, Upperleg_L/Upperleg_R)
2. For each vertex near the center line (|X| < 0.02):
   - If X > ε and Right weight > Left weight: swap detected
   - If X < -ε and Left weight > Right weight: swap detected
3. Swaps the L/R weights when inconsistency is detected

## Changes

- `get_lr_bone_counterpart()`: Get L/R counterpart bone name (_L→_R, .L→.R, Left→Right)
- `build_lr_bone_pairs()`: Build list of L/R bone pairs from avatar data
- `fix_centerline_lr_weight_swaps()`: Detect and fix swapped weights
- Updated CHANGELOG with PR #62 fix details

## Test Results

**Costume_Body** (before → after):

| Bone Pair | Max Diff Before | Max Diff After |
|-----------|-----------------|----------------|
| Butt_L/Butt_R | 0.0777 | 0.0000 ✓ |
| Upperleg_L/Upperleg_R | 0.0633 | 0.0000 ✓ |

L/R swap issues completely resolved for Costume_Body!

## Related Issues

- Closes #60 (completes the fix started in PR #61)
- PR #61: Fixed `temporarily_merge_for_weight_transfer` cKDTree issue
- PR #62: Fixed `process_weight_transfer` external addon issue (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)