### PR TITLE
fix: Numba JIT cache=True causes hang on MS Store Blender

### DIFF
--- a/MochiFitter-BlenderAddon/rbf_multithread_processor.py
+++ b/MochiFitter-BlenderAddon/rbf_multithread_processor.py
@@ -153,7 +153,9 @@ DEFAULT_DTYPE = np.float32
 # Numba JIT高速化関数（P2-1）
 # =============================================================================
 
-@jit(nopython=True, parallel=True, fastmath=True, cache=True, nogil=True)
+# cache=False: Microsoft Store版Blenderのサンドボックス環境で
+# キャッシュディレクトリへのアクセスがハングする問題を回避
+@jit(nopython=True, parallel=True, fastmath=True, cache=False, nogil=True)
 def _cdist_sqeuclidean_numba(A: np.ndarray, B: np.ndarray) -> np.ndarray:
     """
     Numba JIT版 二乗ユークリッド距離計算
@@ -184,7 +186,9 @@ def _cdist_sqeuclidean_numba(A: np.ndarray, B: np.ndarray) -> np.ndarray:
     return result
 
 
-@jit(nopython=True, parallel=True, fastmath=True, cache=True, nogil=True)
+# cache=False: Microsoft Store版Blenderのサンドボックス環境で
+# キャッシュディレクトリへのアクセスがハングする問題を回避
+@jit(nopython=True, parallel=True, fastmath=True, cache=False, nogil=True)
 def _cdist_euclidean_numba(A: np.ndarray, B: np.ndarray) -> np.ndarray:
     """
     Numba JIT版 ユークリッド距離計算


### PR DESCRIPTION
## Summary

- Numba JIT の `cache=True` を `cache=False` に変更
- Microsoft Store 版 Blender の AppContainer サンドボックス環境でのハングを回避

## 変更内容

`rbf_multithread_processor.py`:
- `_cdist_sqeuclidean_numba()`: `cache=True` → `cache=False`
- `_cdist_euclidean_numba()`: `cache=True` → `cache=False`

## 原因

Numba の `@jit(cache=True)` デコレータは `__pycache__` ディレクトリにコンパイル結果をキャッシュしようとするが、Microsoft Store 版 Blender の AppContainer サンドボックス環境ではこのアクセスがブロックされ、関数定義時に無限ハングする。

## トレードオフ

| 項目 | cache=True | cache=False |
|------|-----------|-------------|
| 起動時間 | 高速（キャッシュ済み） | 毎回 JIT コンパイル（数秒） |
| MS Store Blender | ハング | 正常動作 |
| 通常版 Blender | 正常動作 | 正常動作 |

## Test plan

- [x] Blender 5.0 (Microsoft Store版) で NPZ 生成が正常に開始されることを確認

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)